### PR TITLE
Fixed bug in which the region wasn't selected if it was found by the …

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -134,7 +134,7 @@ watch(
       if (regionSelected.value && metric) {
         // Set the selected metric ID in the map store
         mapStore.selectedRegionMetricId = metric.id;
-        await mapStore.fetchSelectedRegion(regionSelected.value.id);
+        await mapStore.fetchSelectedRegion(regionSelected.value.id, metric.id);
         regionSelected.value = null; // Reset the selection after setting
         suggestions.value = []; // Clear suggestions after selection
       }


### PR DESCRIPTION
This pull request refactors the `AnomalyMap` component and related files to centralize map-related state and logic in the `mapStore`. The changes improve maintainability by reducing redundancy, ensuring consistency, and leveraging Vue's reactivity system. Key updates include replacing local state with `mapStore` properties, modifying the `fetchSelectedRegion` method to accept a metric ID, and introducing new properties in `mapStore`.

### Refactoring of `AnomalyMap` component:

* Replaced local `projection` and `MVTFormat` with `mapStore.projection` and `mapStore.format` for consistent state management. (`src/components/AnomalyMap.vue`: [[1]](diffhunk://#diff-76078cc0e943e6d7e95d618ba45b4276ac1d8ff3565f0a364f2c290e40b479c4L16-R16) [[2]](diffhunk://#diff-76078cc0e943e6d7e95d618ba45b4276ac1d8ff3565f0a364f2c290e40b479c4L32-R32) [[3]](diffhunk://#diff-76078cc0e943e6d7e95d618ba45b4276ac1d8ff3565f0a364f2c290e40b479c4L110-R111) [[4]](diffhunk://#diff-76078cc0e943e6d7e95d618ba45b4276ac1d8ff3565f0a364f2c290e40b479c4L129-R135)
* Added a computed property `selectedFeatures` to reference `mapStore.selectedFeatures`, simplifying reactivity in the component. (`src/components/AnomalyMap.vue`: [src/components/AnomalyMap.vueR97](diffhunk://#diff-76078cc0e943e6d7e95d618ba45b4276ac1d8ff3565f0a364f2c290e40b479c4R97))
* Updated watchers and logic to use `selectedFeatures` instead of directly referencing `mapStore.selectedFeatures`. (`src/components/AnomalyMap.vue`: [[1]](diffhunk://#diff-76078cc0e943e6d7e95d618ba45b4276ac1d8ff3565f0a364f2c290e40b479c4L259-R261) [[2]](diffhunk://#diff-76078cc0e943e6d7e95d618ba45b4276ac1d8ff3565f0a364f2c290e40b479c4L278-R279) [[3]](diffhunk://#diff-76078cc0e943e6d7e95d618ba45b4276ac1d8ff3565f0a364f2c290e40b479c4L304-R307)

### Enhancements to `mapStore`:

* Introduced new properties: `format`, `projection`, and `extent` for centralized map configuration. (`src/stores/mapStore.ts`: [src/stores/mapStore.tsL12-R18](diffhunk://#diff-0c7ed010f1d95821a46379371b28963cea3d5c41a84af6bb95da694ad8a14917L12-R18))
* Modified the `fetchSelectedRegion` method to accept a `metricId` and set it as the feature ID, ensuring alignment with the selected metric. (`src/stores/mapStore.ts`: [src/stores/mapStore.tsL50-R62](diffhunk://#diff-0c7ed010f1d95821a46379371b28963cea3d5c41a84af6bb95da694ad8a14917L50-R62))

### Updates to `SearchBox` component:

* Updated the call to `fetchSelectedRegion` to include the selected metric ID as a parameter. (`src/components/SearchBox.vue`: [src/components/SearchBox.vueL137-R137](diffhunk://#diff-e65075cfc8c5aab102c51f98cf174702bc3d8046cf3a008e123704325c190362L137-R137))…search box

Closes #7 