### PR TITLE
Reset scroll position to the top when selecting another region.

### DIFF
--- a/src/components/RegionDetailedDrawer/index.vue
+++ b/src/components/RegionDetailedDrawer/index.vue
@@ -53,7 +53,10 @@
       </div>
     </div>
     <!-- * CONTENT -->
-    <q-scroll-area class="drawer-content full-height q-px-md q-py-xs col overflow-auto">
+    <q-scroll-area
+      ref="drawerScrollArea"
+      class="drawer-content full-height q-px-md q-py-xs col overflow-auto"
+    >
       <RegionAnomaliesChart class="q-pt-sm" />
       <RegionSeasonality />
       <RegionSummary />
@@ -72,10 +75,12 @@ import {
   anomalyClassificationStyle,
   classifyAnomaly,
 } from 'src/utils/anomalyClassification';
-import { computed, onMounted, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 
 const uiStore = useUIStore();
 const mapStore = useMapStore();
+
+const drawerScrollArea = ref(null as any);
 
 const updateDataHook = async () => {
   if (!mapStore.selectedRegionMetricId) return;
@@ -93,6 +98,10 @@ watch(
   () => mapStore.selectedRegionMetricId,
   async (newValue, oldValue) => {
     if (newValue !== oldValue) {
+      // Also, reset the scroll position of the drawer
+      if (drawerScrollArea.value) {
+        drawerScrollArea.value?.setScrollPosition('vertical', 0, 150);
+      }
       await updateDataHook();
     }
   },


### PR DESCRIPTION
This pull request introduces a feature to reset the scroll position of the `RegionDetailedDrawer` component whenever the selected region metric changes. It also includes minor refactoring to support this functionality.

### Feature Addition:
* **Scroll Reset on Metric Change**: Added a `ref` for the `q-scroll-area` component (`drawerScrollArea`) and implemented logic in the `watch` function to reset the vertical scroll position with a smooth transition when the `selectedRegionMetricId` changes. (`src/components/RegionDetailedDrawer/index.vue`, [[1]](diffhunk://#diff-eed3b9fb63a368c07ac912483d67f389ba28d25034184ab25f3e7f68bdcc999aL56-R59) [[2]](diffhunk://#diff-eed3b9fb63a368c07ac912483d67f389ba28d25034184ab25f3e7f68bdcc999aR101-R104)

### Refactoring:
* **Imports Update**: Added `ref` to the Vue imports to support the new scroll reset functionality. (`src/components/RegionDetailedDrawer/index.vue`, [src/components/RegionDetailedDrawer/index.vueL75-R84](diffhunk://#diff-eed3b9fb63a368c07ac912483d67f389ba28d25034184ab25f3e7f68bdcc999aL75-R84))

Closes #10 