### PR TITLE
Add actual value on region hovering

### DIFF
--- a/src/components/AnomalyMap/index.vue
+++ b/src/components/AnomalyMap/index.vue
@@ -350,7 +350,7 @@ const hoverFeature = async (event: MapBrowserEvent<PointerEvent>) => {
   }
   tooltipEl.innerHTML = `
   <div><strong>${feature.get('region__name')}</strong></div>
-  <div>Value: ${feature.get('value')}</div>
+  <div>Bites Index: <i>${(feature.get('value') * 100).toFixed(1)}%</i></div>
   `;
   tooltipEl.classList.add('visible');
   hoverOverlay.setPosition(event.coordinate);


### PR DESCRIPTION
This pull request updates the `hoverFeature` #62 unction in `src/components/AnomalyMap/index.vue` to enhance tooltip functionality and restore conditional logic for playback-enabled scenarios.

Enhancements to tooltip functionality:

* Updated `tooltipEl.innerHTML` to display a more detailed tooltip, including the region name and value, formatted with HTML for better readability.

Restoration of playback-enabled logic:

* Reintroduced conditional logic to handle playback-enabled scenarios, ensuring that the `value` property of the hovered feature is updated based on the current playback date.

Closes #62 