### PR TITLE
51 line at the start of the year on the anomalies chart

### DIFF
--- a/src/components/AnomalyMap/RegionDetailedDrawer/RegionAnomaliesChart.vue
+++ b/src/components/AnomalyMap/RegionDetailedDrawer/RegionAnomaliesChart.vue
@@ -57,7 +57,7 @@ const percentageLastMonth = computed(() => {
   return 100 - ((365 * 2) / anomaliesData.value.length) * 100; // Assuming the last month has 30 days
 });
 
-// Calculate the indexes for today and the beginning of the year, to mark the dates on the chart
+// Calculates the indexes for today and the beginning of the year, to mark the dates on the chart
 const indexes = computed(() => {
   const today = new Date(mapStore.currentDate);
   const todayString = date.formatDate(today, 'YYYY-MM-DD');
@@ -83,14 +83,6 @@ const indexes = computed(() => {
   });
   return { indexToday, indexLastYearFirstDay };
 });
-
-// const indexToday = computed(() => {
-//   const today = new Date(mapStore.currentDate);
-//   const todayString = date.formatDate(today, 'YYYY-MM-DD');
-//   return anomaliesData.value.findIndex(
-//     (item) => date.formatDate(item.date, 'YYYY-MM-DD') === todayString,
-//   );
-// });
 
 const option = computed(() => {
   return {

--- a/src/components/AnomalyMap/RegionDetailedDrawer/index.vue
+++ b/src/components/AnomalyMap/RegionDetailedDrawer/index.vue
@@ -17,7 +17,7 @@
         <div class="col-10">
           <p class="text-h6 text-weight-regular" style="color: #333">{{ provinceName }}</p>
           <p class="text-subtitle-1 text-weight-regular q-ma-none" style="color: #333">
-            {{ mapStore.currentDate }}
+            {{ date.formatDate(mapStore.currentDate, 'MMM D, YYYY') }}
           </p>
         </div>
         <div class="col self-end">
@@ -57,7 +57,9 @@
 
 <script setup lang="ts">
 import { MetricDetail } from 'anomaly-detection';
+import { date } from 'quasar';
 import { historyPageSize } from 'src/constants/config';
+import { useMapStore } from 'src/stores/mapStore';
 import { useUIStore } from 'src/stores/uiStore';
 import {
   AnomalyClassificationEnum,
@@ -66,12 +68,9 @@ import {
 } from 'src/utils/anomalyClassification';
 import { computed, ref, watch } from 'vue';
 import { useRegionDetailedStore } from '../../../stores/regionDetailedStore';
-import { usePlaybackStore } from 'src/stores/playbackStore';
-import { useMapStore } from 'src/stores/mapStore';
 
 const uiStore = useUIStore();
 const regionDetailedStore = useRegionDetailedStore();
-const playbackStore = usePlaybackStore();
 const mapStore = useMapStore();
 
 const drawerScrollArea = ref(null as any);


### PR DESCRIPTION
This pull request refactors the anomaly chart and improves date formatting across the `RegionDetailedDrawer` component. The key changes include the introduction of computed indexes for chart markers, adjustments to the chart's data configuration, and a more user-friendly date format for display.

### Refactoring anomaly chart markers:

* [`src/components/AnomalyMap/RegionDetailedDrawer/RegionAnomaliesChart.vue`](diffhunk://#diff-da4feadefb857113e2d2722988ca3af821694454342ed1abcdeffe0567ab429fL59-R84): Replaced the `indexToday` computed property with a new `indexes` computed property that calculates both today's index and the index of the first day of the year for better chart marker flexibility.
* [`src/components/AnomalyMap/RegionDetailedDrawer/RegionAnomaliesChart.vue`](diffhunk://#diff-da4feadefb857113e2d2722988ca3af821694454342ed1abcdeffe0567ab429fL210-R231): Updated the chart configuration to use the new `indexes` property, including adding a marker for the beginning of the year with a dotted line style. [[1]](diffhunk://#diff-da4feadefb857113e2d2722988ca3af821694454342ed1abcdeffe0567ab429fL210-R231) [[2]](diffhunk://#diff-da4feadefb857113e2d2722988ca3af821694454342ed1abcdeffe0567ab429fR242-R251)

### Improved date formatting:

* [`src/components/AnomalyMap/RegionDetailedDrawer/index.vue`](diffhunk://#diff-2cb3d72efeb00b769785d3f4969e552c61ad86c53e2b7111ca7928810bd3ec42L20-R20): Changed the display format of `mapStore.currentDate` to a more readable format (`MMM D, YYYY`).

### Code cleanup:

* [`src/components/AnomalyMap/RegionDetailedDrawer/index.vue`](diffhunk://#diff-2cb3d72efeb00b769785d3f4969e552c61ad86c53e2b7111ca7928810bd3ec42L69-L74): Removed unused imports (`usePlaybackStore`) and reorganized the imports for better clarity.

Closes #51 