### PR TITLE
Fixed initial zoom extention to Spain

### DIFF
--- a/src/components/AnomalyMap/index.vue
+++ b/src/components/AnomalyMap/index.vue
@@ -78,7 +78,7 @@ import { Geometry } from 'ol/geom';
 import { Layer } from 'ol/layer';
 import VectorTileLayer from 'ol/layer/VectorTile';
 import type MapRef from 'ol/Map';
-import { fromLonLat } from 'ol/proj';
+import { fromLonLat, transformExtent } from 'ol/proj';
 import { Fill, Stroke, Style } from 'ol/style';
 import { getCssVar, useQuasar } from 'quasar';
 import { ANOMALY_COLORS } from 'src/constants/colors';
@@ -286,6 +286,14 @@ onMounted(() => {
   if (!map) {
     return;
   }
+
+  const spainExtent = [-9.5, 35.9, 3.3, 43.9];
+  const spainExtent3857 = transformExtent(spainExtent, 'EPSG:4326', mapStore.projection);
+  map.getView().fit(spainExtent3857, {
+    size: map.getSize(),
+    padding: [50, 50, 50, 50], // Padding around the feature
+    duration: 200, // duration of the zoom animation in milliseconds
+  });
 
   map.addOverlay(hoverOverlay);
 

--- a/src/pages/AnomalyMapPage.vue
+++ b/src/pages/AnomalyMapPage.vue
@@ -29,7 +29,7 @@
           <q-tooltip anchor="center left" self="center end">{{ playbackTooltipMsg }}</q-tooltip>
         </div>
       </div>
-      <div class="playback sidemap-option" :class="{ active: autonomousCommunitiesActive }">
+      <div class="sidemap-option" :class="{ active: autonomousCommunitiesActive }">
         <div @click="mapStore.showAutonomousCommunities = !mapStore.showAutonomousCommunities">
           <span v-if="!mapStore.fetchingDate" class="column items-center">
             <q-icon :name="mapStore.showAutonomousCommunities ? 'layers' : 'layers_clear'"></q-icon>
@@ -46,7 +46,7 @@
     <!-- PLAYBACK CONTROL -->
     <q-page-sticky
       position="bottom-left"
-      :offset="[20, 20]"
+      :offset="[0, 2]"
       class="sticky-playback-control flex justify-center"
     >
       <PlaybackControl


### PR DESCRIPTION
This pull request introduces enhancements to the `AnomalyMap` component and its related page, improving map functionality and refining UI elements. The most significant changes involve adding a new map extent for Spain, adjusting playback control offsets, and simplifying class usage for a sidebar option.

### Map functionality improvements:

* [`src/components/AnomalyMap/index.vue`](diffhunk://#diff-3159c807667c5095285e543f077ce24aeb481e885d09a092694848ef06db4a21L81-R81): Added `transformExtent` import and implemented functionality to fit the map view to Spain's extent (`spainExtent3857`) with padding and animation during initialization. [[1]](diffhunk://#diff-3159c807667c5095285e543f077ce24aeb481e885d09a092694848ef06db4a21L81-R81) [[2]](diffhunk://#diff-3159c807667c5095285e543f077ce24aeb481e885d09a092694848ef06db4a21R290-R297)

### UI refinements:

* [`src/pages/AnomalyMapPage.vue`](diffhunk://#diff-028a5d95a8cb09204e74e6aa76956171caec7fc5428659ce0a24acaf8be0167aL32-R32): Removed redundant "playback" class from the sidebar option to simplify styling.
* [`src/pages/AnomalyMapPage.vue`](diffhunk://#diff-028a5d95a8cb09204e74e6aa76956171caec7fc5428659ce0a24acaf8be0167aL49-R49): Adjusted playback control sticky offset values for better positioning on the page.

Closes #11 