### PR TITLE
URLs depending on the environment.

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,2 @@
+API_BASE_URL=http://localhost:8000/api/v1
+GEOSERVER_URL=http://localhost:8080/geoserver/mosquitoalert/wms

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 
 # VScode directories
 .vscode
+
+# .env files
+.env.prod

--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -38,9 +38,7 @@ export default defineConfig((ctx) => {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#build
     build: {
-      env: {
-        API_BASE_URL: isDev ? 'http://localhost:8000/api/v1' : undefined,
-      },
+      env: {},
       target: {
         browser: ['es2022', 'firefox115', 'chrome115', 'safari14'],
         node: 'node20',

--- a/src/components/AnomalyMap/index.vue
+++ b/src/components/AnomalyMap/index.vue
@@ -26,7 +26,7 @@
         />
       </ol-tile-layer>
 
-      <ol-tile-layer :z-index="7" v-if="mapStore.showLabels">
+      <ol-tile-layer :z-index="7" :visible="mapStore.showLabels">
         <ol-source-xyz
           :url="mapStore.labelsLayer.url"
           :preload="mapStore.labelsLayer.preload"
@@ -214,7 +214,8 @@ const getWmsSource = (styleName: string) =>
     // crossOrigin: 'anonymous',
     projection: mapStore.projection,
     // TODO: Dynamic URL
-    url: 'http://localhost:8080/geoserver/mosquitoalert/wms',
+    url: process.env.GEOSERVER_URL,
+    //'http://localhost:8080/geoserver/mosquitoalert/wms',
     params: {
       LAYERS: `mosquitoalert:${styleName}`,
       SRS: mapStore.projection,


### PR DESCRIPTION
This pull request introduces changes to impro#77 environment variable management, streamline configuration, and enhance map component functionality. The most notable updates include centralizing API and GeoServer URLs in the `.env.dev` file, modifying the Quasar configuration to simplify environment variables, and enhancing map layer visibility handling.

### Environment Variable Management:
* [`.env.dev`](diffhunk://#diff-7a7fc1ad605f5451f39444d73266644788cd3cfb0cf432d1f0022643dbe50da3R1-R2): Added `API_BASE_URL` and `GEOSERVER_URL` environment variables to centralize configuration for API and GeoServer endpoints.

### Configuration Simplification:
* [`quasar.config.ts`](diffhunk://#diff-a839c3a16b84422aa3c66df5d6f4ce2ec18c3adc36bda42c15a87ab4cb0b4470L41-R41): Removed `API_BASE_URL` from the `build.env` configuration, simplifying environment variable handling.

### Map Component Enhancements:
* [`src/components/AnomalyMap/index.vue`](diffhunk://#diff-3159c807667c5095285e543f077ce24aeb481e885d09a092694848ef06db4a21L29-R29): Updated `ol-tile-layer` to use the `:visible` property instead of `v-if` for controlling label layer visibility, improving performance and reactivity.
* [`src/components/AnomalyMap/index.vue`](diffhunk://#diff-3159c807667c5095285e543f077ce24aeb481e885d09a092694848ef06db4a21L217-R218): Refactored the `getWmsSource` function to use the `GEOSERVER_URL` environment variable for dynamic GeoServer endpoint configuration.

Closes #77