### PR TITLE
Playback wait for render before moving to the next day.

### DIFF
--- a/src/components/BiteIndexMap/index.vue
+++ b/src/components/BiteIndexMap/index.vue
@@ -7,6 +7,7 @@
       :loadTilesWhileInteracting="true"
       @click="selectFeature"
       @pointermove="hoverFeature"
+      @rendercomplete="playbackStore.renderCompleted = true"
       :controls="[]"
     >
       <ol-view


### PR DESCRIPTION
This pull request introduces changes to improve the playback functionality in the `playbackStore` and integrates a mechanism to ensure rendering completion before proceeding with playback updates. The most important changes include adding a `renderCompleted` flag to track rendering status, updating the `play` method to wait for rendering completion, and modifying the `BiteIndexMap` component to set the `renderCompleted` flag when rendering is complete.

### Playback functionality improvements:

* **Added `renderCompleted` flag**: Introduced a new state property `renderCompleted` in the `playbackStore` to track whether the WMS rendering process has completed.

* **Updated `play` method**: Refactored the `play` method in `playbackStore` to use an asynchronous loop that waits for rendering completion or a timeout before proceeding to the next playback step. Added helper methods `delay` and `waitForRenderOrTimeout` to manage timing and rendering checks.

### Component integration:

* **Integrated rendering completion flag**: Modified the `BiteIndexMap` component to set the `renderCompleted` flag in the `playbackStore` when the rendering process is complete using the `@rendercomplete` event.

Closes #75 